### PR TITLE
Fix instructions of object destructuring (SyntaxError), add instructions for property renaming

### DIFF
--- a/es6.rst
+++ b/es6.rst
@@ -240,7 +240,7 @@ We can coerce other values to booleans with the ``Boolean`` wrapper. Most values
   * - ``true``
     - ``false``
   * - Most objects
-    - ``nulll``
+    - ``null``
   * -  ``1``
     - ``0`` or ``-0``
   * - ``"string"``

--- a/es6.rst
+++ b/es6.rst
@@ -151,8 +151,21 @@ Default values can also be provided for object destructuring::
 
   let paul = {name: 'Paul', year: 1942};
 
-  let {name:'Joe', inst:'Guitar', year} = paul;
+  let {name = 'Joe', inst = 'Guitar', year} = paul;
 
+
+We can also rename the properties during object destrucruting::
+
+  let paul = {name: 'Paul', year: 1942};
+
+  let {name: firstname, inst: instrument, year} = paul;
+
+
+...and we can combine renaming with default values::
+
+  let paul = {name: 'Paul', year: 1942};
+
+  let {name: firstname = 'Joe', inst: instrument = 'Guitar', year} = paul;
 
 Types
 ===============


### PR DESCRIPTION
I believe I found a mistake :)

![image](https://user-images.githubusercontent.com/5426427/28486335-50874424-6e81-11e7-8f45-eabed2943090.png)
